### PR TITLE
doc update, secure params, conflict bug

### DIFF
--- a/.github/workflows/action_deploy_aro_enterprise.yml
+++ b/.github/workflows/action_deploy_aro_enterprise.yml
@@ -178,6 +178,7 @@ jobs:
           aadObjectId="${{ secrets.AAD_OBJECT_ID }}"
           rpObjectId="${{ secrets.ARO_SP_OB_ID }}"
           spokeVnetName="${{ env.SPOKE_VNET }}"
+          addSpRoleAssignment='no'
         deploymentName: aro-github-actions
 
   deploy_bastion:

--- a/deploy_azcli/aro_enterprise.bicep
+++ b/deploy_azcli/aro_enterprise.bicep
@@ -4,6 +4,8 @@ targetScope = 'subscription'
 param aadClientId string
 
 @description('The secret of an Azure Active Directory client application')
+
+@secure()
 param aadClientSecret string
 
 @description('The ObjectID of the Azure Active Directory Service Principal')
@@ -61,6 +63,7 @@ param computeVnetName string
 param computeSubnetCidr string
 
 @description('Pull secret from cloud.redhat.com. The json should be input as a string')
+@secure()
 param pullSecret string
 
 @description('Api Server Visibility')
@@ -123,6 +126,8 @@ param jumpbox_image_offer string
 param jumpbox_image_sku string
 param jumpbox_image_version string
 param adminUsername string
+
+@secure()
 param adminPassword string
 
 @description('Name for firewall public ip')
@@ -263,6 +268,7 @@ module aro_cluster '../modules/aro_cluster.bicep' = {
     fipsValidatedModules: fipsValidatedModules
     encryptionAtHost: encryptionAtHost
     rpObjectId: rpObjectId
+    addSpRoleAssignment: 'no'
   }
 }
 

--- a/modules/aro_cluster.bicep
+++ b/modules/aro_cluster.bicep
@@ -30,13 +30,14 @@ param controlPlaneVnetName string
 param computeVnetName string
 param fipsValidatedModules string
 param encryptionAtHost string
+param addSpRoleAssignment string
 
 var contribRole = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 
 resource clusterVnet 'Microsoft.Network/virtualNetworks@2021-08-01' existing = { name: spokeVnetName }
 
-resource role_for_aadObjectId 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
-  name: guid( resourceGroup().id, aadObjectId, contribRole)
+resource role_for_aadObjectId 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = if (addSpRoleAssignment == 'yes') {
+  name: guid(resourceGroup().id, aadObjectId, deployment().name)
   properties: {
     principalId: aadObjectId
     principalType: 'ServicePrincipal'
@@ -48,7 +49,7 @@ resource role_for_aadObjectId 'Microsoft.Authorization/roleAssignments@2020-10-0
 }
 
 resource role_for_rpObjectId 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
-  name: guid( resourceGroup().id, rpObjectId, contribRole)
+  name: guid(resourceGroup().id, rpObjectId)
   properties: {
     principalId: rpObjectId
     principalType: 'ServicePrincipal'
@@ -66,7 +67,7 @@ resource aro 'Microsoft.RedHatOpenShift/openShiftClusters@2022-04-01' = {
   properties: {
     clusterProfile: {
       domain: domain
-      resourceGroupId: '/subscriptions/${subscription().subscriptionId}/resourceGroups/aro-${domain}'
+      resourceGroupId: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${domain}-${clusterName}-${location}'
       pullSecret: pullSecret
       fipsValidatedModules: fipsValidatedModules
     }


### PR DESCRIPTION
This provides a parameter "addSpRoleAssignment" which can be set to yes or no. Setting this for the corresponding deployment method can prevent a deployment failure on Azure where the role assignment is already set.

Documentation updated to include ways to determine APPID var

@secure() set on some parameters to prevent warnings and subsequent failures.